### PR TITLE
Feat/init

### DIFF
--- a/bin/adamant.js
+++ b/bin/adamant.js
@@ -14,6 +14,8 @@ import config from '../utils/config.js';
 
 import packageInfo from '../package.json' assert { type: 'json' };
 
+import installInitCommand from './init.js';
+
 import installAccountCommands from '../lib/account.js';
 import installGetCommands from '../lib/get.js';
 import installNodeCommands from '../lib/node.js';
@@ -78,6 +80,7 @@ installSendCommands(program);
 installRpcServerCommands(program);
 installDelegateCommands(program);
 installVoteCommands(program);
+installInitCommand(program);
 
 const client = program.command('client');
 

--- a/bin/adamant.js
+++ b/bin/adamant.js
@@ -12,7 +12,7 @@ import prompt from '../prompt/index.js';
 import { log } from '../utils/log.js';
 import config from '../utils/config.js';
 
-import packageInfo from '../package.json' assert { type: 'json' };
+import { packageInfo } from '../utils/package.js';
 
 import installInitCommand from './init.js';
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -4,6 +4,8 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { configFileName, configPathName } from '../utils/config.js';
+
 const homeDir = os.homedir();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -11,20 +13,20 @@ export default (program) => {
   program
     .command('init')
     .description(
-      'Copies default config file into the given path directory or inside ~/.adm',
+      `Copies default config file into the given path directory or inside ~/${configPathName}`,
     )
     .argument('[path]', 'directory path to copy config into')
-    .action(async (targetDirectory = path.join(homeDir, '.adm')) => {
+    .action(async (targetDirectory = path.join(homeDir, configPathName)) => {
       if (!fs.existsSync(targetDirectory)) {
         fs.mkdirSync(targetDirectory, { recursive: true });
       }
 
       const defaultConfigPath = path.join(__dirname, '../config.default.jsonc');
-      const targetFilePath = path.resolve(targetDirectory, 'config.jsonc');
+      const targetFilePath = path.resolve(targetDirectory, configFileName);
 
       if (fs.existsSync(targetFilePath)) {
         console.error(
-          `Error: The file config.jsonc already exists in ${targetDirectory}. Please remove or rename it.`,
+          `Error: The file ${configFileName} already exists in ${targetDirectory}. Please remove or rename it.`,
         );
         return;
       }

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,22 +1,19 @@
-import os from 'os';
 import fs from 'fs';
-
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { configFileName, configPathName } from '../utils/config.js';
+import { configFileName, configDirPath } from '../utils/config.js';
 
-const homeDir = os.homedir();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default (program) => {
   program
     .command('init')
     .description(
-      `Copies default config file into the given path directory or inside ~/${configPathName}`,
+      `Copies default config file into the given path directory or inside ${configDirPath}`,
     )
     .argument('[path]', 'directory path to copy config into')
-    .action(async (targetDirectory = path.join(homeDir, configPathName)) => {
+    .action(async (targetDirectory = configDirPath) => {
       if (!fs.existsSync(targetDirectory)) {
         fs.mkdirSync(targetDirectory, { recursive: true });
       }

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,0 +1,44 @@
+import os from 'os';
+import fs from 'fs';
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const homeDir = os.homedir();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default (program) => {
+  program
+    .command('init')
+    .description(
+      'Copies default config file into the given path directory or inside ~/.adm',
+    )
+    .argument('[path]', 'directory path to copy config into')
+    .action(async (targetDirectory = path.join(homeDir, '.adm')) => {
+      if (!fs.existsSync(targetDirectory)) {
+        fs.mkdirSync(targetDirectory, { recursive: true });
+      }
+
+      const defaultConfigPath = path.join(__dirname, '../config.default.jsonc');
+      const targetFilePath = path.resolve(targetDirectory, 'config.jsonc');
+
+      if (fs.existsSync(targetFilePath)) {
+        console.error(
+          `Error: The file config.jsonc already exists in ${targetDirectory}. Please remove or rename it.`,
+        );
+        return;
+      }
+
+      fs.copyFile(defaultConfigPath, targetFilePath, (error) => {
+        if (error) {
+          console.error('Error copying the config file:', error);
+        } else {
+          console.log(
+            `Config was successfully initialized in ${targetFilePath}`,
+          );
+          console.log('Edit it using the following command:');
+          console.log(`    nano '${targetFilePath}'`);
+        }
+      });
+    });
+};

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -4,7 +4,7 @@ import * as api from './api/index.js';
 import * as log from '../utils/log.js';
 import config from '../utils/config.js';
 
-import packageInfo from '../package.json' assert { type: 'json' };
+import { packageInfo } from '../utils/package.js';
 
 /**
  * Safe callback and error handling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant-console",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Console API and JSON-RPC for interacting with ADAMANT Blockchain",
   "main": "lib/api/index.js",
   "type": "module",

--- a/prompt/index.js
+++ b/prompt/index.js
@@ -1,6 +1,6 @@
 import readline from 'readline';
 import History from './history.js';
-import packageInfo from '../package.json' assert { type: 'json' };
+import { packageInfo } from '../utils/package.js';
 
 export default (callback) => {
   const rl = readline.createInterface({

--- a/utils/config.js
+++ b/utils/config.js
@@ -11,8 +11,8 @@ import chalk from 'chalk';
 
 import * as log from './log.js';
 
-const configPathName = '.adm';
-const configFileName = process.env.ADM_CONFIG_FILENAME || 'config.jsonc';
+export const configPathName = '.adm';
+export const configFileName = process.env.ADM_CONFIG_FILENAME || 'config.jsonc';
 
 const homeDir = os.homedir();
 const configDirPath =

--- a/utils/config.js
+++ b/utils/config.js
@@ -11,11 +11,12 @@ import chalk from 'chalk';
 
 import * as log from './log.js';
 
-export const configPathName = '.adm';
-export const configFileName = process.env.ADM_CONFIG_FILENAME || 'config.jsonc';
-
 const homeDir = os.homedir();
-const configDirPath =
+
+const configPathName = '.adm';
+
+export const configFileName = process.env.ADM_CONFIG_FILENAME || 'config.jsonc';
+export const configDirPath =
   process.env.ADM_CONFIG_PATH || `${homeDir}/${configPathName}`;
 
 const configFilePath = path.normalize(`${configDirPath}/${configFileName}`);

--- a/utils/package.js
+++ b/utils/package.js
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const packageInfo = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'),
+);


### PR DESCRIPTION
Added `adm init [path]` command to copy default config with overwriting protection instead of using one of the commands from documentation.

### Before

```bash
# nvm
mkdir ~/.adm && cp ~/.nvm/versions/node/$(node -v)/lib/node_modules/adamant-console/config.default.jsonc ~/.adm/config.jsonc && nano ~/.adm/config.jsonc
# npm
mkdir ~/.adm && cp /usr/lib/node_modules/adamant-console/config.default.jsonc ~/.adm/config.jsonc && nano ~/.adm/config.jsonc
# source
mkdir ~/.adm && cp ~/adamant-console/config.default.jsonc ~/.adm/config.jsonc && nano ~/.adm/config.jsonc
```

### After

```bash
# to copy to ~/.adm/$ADM_CONFIG_FILENAME
$ adm init
# to copy to the specific directory
$ adm init ./my-dir
```