### PR TITLE
Feat: Syntax-highlight JSON console output

### DIFF
--- a/utils/log.js
+++ b/utils/log.js
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+
 /**
  * Formats an object as pretty JSON.
  *
@@ -7,7 +9,42 @@
 const stringify = (obj = {}) => JSON.stringify(obj, null, 2);
 
 /**
- * Writes merged objects as pretty JSON to stdout.
+ * Matches the syntactic tokens of pretty-printed JSON: a string (optionally a
+ * key when followed by a colon), a boolean, `null`, or a number.
+ */
+const JSON_TOKEN =
+  /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false)\b|\bnull\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+
+/**
+ * Colorizes a pretty-printed JSON string for terminal output.
+ *
+ * Coloring is applied per token (keys, strings, numbers, booleans, `null`); the
+ * JSON payload itself is unchanged. When stdout is not a TTY or color is
+ * disabled (e.g. `NO_COLOR`), `chalk` emits no escape codes, so piped or
+ * redirected output stays plain and machine-parseable.
+ *
+ * @param {string} json Pretty JSON produced by `stringify`
+ * @returns {string} The same JSON with ANSI color codes added where applicable
+ */
+const highlight = (json) =>
+  json.replace(JSON_TOKEN, (match, str, colon, bool, num) => {
+    if (str !== undefined) {
+      return colon !== undefined ? chalk.cyan(str) + colon : chalk.green(str);
+    }
+
+    if (bool !== undefined) {
+      return chalk.yellow(bool);
+    }
+
+    if (num !== undefined) {
+      return chalk.magenta(num);
+    }
+
+    return chalk.gray(match);
+  });
+
+/**
+ * Writes merged objects as pretty, syntax-highlighted JSON to stdout.
  *
  * @param {...object} args Objects to merge into one JSON response
  * @returns {void}
@@ -15,7 +52,7 @@ const stringify = (obj = {}) => JSON.stringify(obj, null, 2);
 export const log = (...args) => {
   const res = Object.assign({}, ...args);
 
-  console.log(stringify(res));
+  console.log(highlight(stringify(res)));
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds syntax highlighting to console JSON output in `utils/log.js`. Responses from CLI, RPC, and library helpers are now colorized per token (keys, strings, numbers, booleans, `null`) for easier reading in the terminal.

Closes #53. Supersedes #37 (the `cli-highlight` implementation).

## Approach

- Implemented with **`chalk`**, which is already a direct dependency — no new runtime dependencies added
- A small regex tokenizer (`JSON_TOKEN`) walks the already-serialized `JSON.stringify(obj, null, 2)` output and colors each token; the JSON payload itself is unchanged
- Color map: keys → cyan, strings → green, numbers → magenta, booleans → yellow, `null` → gray
- Deliberately avoided `cli-highlight`, which pulls in an abandoned `highlight.js@10` plus `yargs`, `mz`, `parse5@5`, etc. — at odds with the project's lightweight / dependency-minimization rules

## Behavior

- Color is applied only when stdout is an interactive TTY
- When piped/redirected or color is disabled (`NO_COLOR`, non-TTY), `chalk` emits no escape codes, so output stays plain, valid, machine-parseable JSON

## Verification

- `npm run lint` passes
- Manual check, colored TTY (`FORCE_COLOR=1`):

```
{
  "success": true,
  "count": 42,
  "active": false,
  "note": "hello",
  "empty": null
}
```

(keys/strings/numbers/booleans/`null` colorized)

- Manual check, piped output: identical to previous plain JSON, no ANSI codes

## Notes

- Single-file change (`utils/log.js`); no changes to `package.json` / `package-lock.json`
- No new tests: output is cosmetic only and the JSON payload is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
